### PR TITLE
Add `hast-util-merge` to the list of utilities

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -443,6 +443,8 @@ The rest is sorted alphabetically based on content after `hast-util-`
     — check if `node` is a JavaScript `script`
 *   [`hast-util-labelable`](https://github.com/syntax-tree/hast-util-labelable)
     — check if `node` is labelable
+*   [`hast-util-merge`](https://github.com/viktor-yakubiv/hast-util-merge)
+    — merges elements or documents
 *   [`hast-util-parse-selector`](https://github.com/syntax-tree/hast-util-parse-selector)
     — create an element from a simple CSS selector
 *   [`hast-util-phrasing`](https://github.com/syntax-tree/hast-util-phrasing)


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]). Leave the
  comments as they are, they won’t show on GitHub.
  We are excited about pull requests, but please try to limit the scope, provide
  a general description of the changes, and remember, it’s up to you to convince
  us to land it.
-->

### Initial checklist

*   [x] I read the support docs <!-- https://github.com/syntax-tree/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/syntax-tree/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/syntax-tree/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Asyntax-tree&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

I propose an utility that merges two hast documents applying some heruistics. I wrote the utility for my own need and find it being raw. I would appreciate your feedback.

<!--do not edit: pr-->
