### PR TITLE
docs(fix): install hast types in development only

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -84,7 +84,7 @@ If you are using TypeScript,
 you can use the hast types by installing them with npm:
 
 ```sh
-npm install @types/hast
+npm install @types/hast -D
 ```
 
 ## Nodes (abstract)


### PR DESCRIPTION
Hi, I just read your documentation and think that installing the @types for hast should probably only be done for development only.